### PR TITLE
Add MVT positioning logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,23 @@ Some elements inside the form require specific data attributes so the JavaScript
 - `data-o-email-only-signup-close`: Applied to the close button
 - `data-o-email-only-signup-completion-message`: Applied to an element that will be replaced with a message when signup is complete
 - `data-o-email-only-signup-email-error`: Applied to an element containing a message to display when the entered email is invalid
+
+**[optional]** If a positioning element exists on the page the form will render as a child of it:
+
+- `data-o-email-only-signup-position-mvt`: Applied to an element to which the form will become a child [see below](#positioning-mvt) for more information.
+
+## Positioning MVT
+
+_**This is optional.** If no positioning element exists the form will render in place._
+
+The position of the signup form within the article (and indeed page) can be customised. This could be used to run a MVT on how the location of the form affects its performance.
+
+A positioning element with the data attribute `data-o-email-only-signup-position-mvt` **must** be present in the DOM. 
+
+If this element exists, the form component will become its child, thus moving the form to its position.
+
+_NOTE:_ you **should** initially render the form in a hidden state in order to avoid a reflow. Simply add the class `o-email-only-signup__visually-hidden` to the form (the `data-o-email-only-signup-form` element), the class will be removed when the component is initialised.
+
+
+
+

--- a/main.js
+++ b/main.js
@@ -4,6 +4,7 @@ export default {
 
 	init(el = document.body, options = {}) {
 		const utmTermParam = /[?&]utm_term(=([^&#]*)|&|#|$)/i.exec(window.location.href);
+		const positionMvt = document.querySelector('[data-o-email-only-signup-position-mvt]');
 
 		let userIsFromLightSignupEmail;
 
@@ -15,15 +16,20 @@ export default {
 			el = document.querySelector(el);
 		}
 
-		if (!userIsFromLightSignupEmail) {
-			if(el.matches('[data-o-component~="o-email-only-signup"]')) {
-				emailOnlySignup.init(el, options);
-			} else {
-				el = el.querySelector('[data-o-component~="o-email-only-signup"]');
-				if(el) {
-					emailOnlySignup.init(el, options);
-				}
+		if (!el.matches('[data-o-component~="o-email-only-signup"]')) {
+			el = el.querySelector('[data-o-component~="o-email-only-signup"]');
+		}
+
+		if (!userIsFromLightSignupEmail && el) {
+
+			// Article Position MVT: move the component and ensure visible
+			if (positionMvt) {
+				positionMvt.appendChild(el);
 			}
+			el.classList.remove('o-email-only-signup__visually-hidden');
+			el.setAttribute('aria-hidden', false);
+
+			emailOnlySignup.init(el, options);
 		}
 	}
 };

--- a/src/email-only-signup.js
+++ b/src/email-only-signup.js
@@ -19,7 +19,6 @@ export default {
 		// Keep marketing copy somewhere
 
 		const pageLocation = window.location.href;
-		const mvtPosition = document.querySelector('[data-o-email-only-signup-mvt-position]');
 
 		const responseMsg = {
 			'SUBSCRIPTION_SUCCESSFUL': 'Thanks – look out for your first briefing soon.',
@@ -28,13 +27,6 @@ export default {
 			'USER_ARCHIVED': 'It looks like you’ve signed up to the daily top stories summary email before. If you’re interested in getting access to more FT content, why not <a target="_blank" style="text-decoration:none;color:#27757B;" href="/products?segID=0801043">sign up to a 4 week Trial</a>?',
 			'USER_NOT_ANONYMOUS': `It looks like you already have an account with us. <a href="/login?location=${pageLocation}" style="text-decoration:none;color:#27757B;">Sign in</a>.`
 		};
-
-		// postion the form and ensure it is visible
-
-		if (mvtPosition) {
-			mvtPosition.appendChild(el);
-		}
-		toggleVisibility(true);
 
 		// Handle user interaction
 
@@ -66,7 +58,8 @@ export default {
 		});
 
 		closeButton.addEventListener('click', () => {
-			toggleVisibility(false);
+			el.style.display = 'none';
+			el.setAttribute('aria-hidden', true);
 		});
 
 		emailField.addEventListener('click', () => {
@@ -102,12 +95,5 @@ export default {
 
 			return options;
 		}
-
-		// @param {Boolean} show - true: display the component. false: hide it
-		function toggleVisibility(show) {
-			el.classList.toggle('o-email-only-signup__visually-hidden', !show);
-			el.setAttribute('aria-hidden', !show);
-		}
-
 	}
 };

--- a/src/email-only-signup.js
+++ b/src/email-only-signup.js
@@ -19,6 +19,7 @@ export default {
 		// Keep marketing copy somewhere
 
 		const pageLocation = window.location.href;
+		const mvtPosition = document.querySelector('[data-o-email-only-signup-mvt-position]');
 
 		const responseMsg = {
 			'SUBSCRIPTION_SUCCESSFUL': 'Thanks – look out for your first briefing soon.',
@@ -27,6 +28,13 @@ export default {
 			'USER_ARCHIVED': 'It looks like you’ve signed up to the daily top stories summary email before. If you’re interested in getting access to more FT content, why not <a target="_blank" style="text-decoration:none;color:#27757B;" href="/products?segID=0801043">sign up to a 4 week Trial</a>?',
 			'USER_NOT_ANONYMOUS': `It looks like you already have an account with us. <a href="/login?location=${pageLocation}" style="text-decoration:none;color:#27757B;">Sign in</a>.`
 		};
+
+		// postion the form and ensure it is visible
+
+		if (mvtPosition) {
+			mvtPosition.appendChild(el);
+		}
+		toggleVisibility(true);
 
 		// Handle user interaction
 
@@ -58,7 +66,7 @@ export default {
 		});
 
 		closeButton.addEventListener('click', () => {
-			el.style.display = 'none';
+			toggleVisibility(false);
 		});
 
 		emailField.addEventListener('click', () => {
@@ -94,5 +102,12 @@ export default {
 
 			return options;
 		}
+
+		// @param {Boolean} show - true: display the component. false: hide it
+		function toggleVisibility(show) {
+			el.classList.toggle('o-email-only-signup__visually-hidden', !show);
+			el.setAttribute('aria-hidden', !show);
+		}
+
 	}
 };


### PR DESCRIPTION
This adds functionality for a MVT test.
It will check the document for a MVT positioning div and move the
component inside it. This functionality was previously done inside
next-article.
The component now starts in a hidden state, is moved if required
and then made visible. Tweaked visibility toggle func to fit this.