### PR TITLE
extract responsemsg stuff so it can be used externally

### DIFF
--- a/src/email-only-signup.js
+++ b/src/email-only-signup.js
@@ -29,70 +29,70 @@ export function init(el, options = {}) {
 
 	const pageLocation = window.location.href;
 
-		// Handle user interaction
-		lightSignupForm.addEventListener('submit', (e) => {
-			e.preventDefault();
+	// Handle user interaction
+	lightSignupForm.addEventListener('submit', (e) => {
+		e.preventDefault();
 
-			const email = emailField.value;
+		const email = emailField.value;
 
-			if (isValidEmail(email)) {
-				const opts = {
-					method: 'POST',
-					headers: {
-						'Content-type': 'application/x-www-form-urlencoded'
-					},
-					credentials: 'include',
-					body: `email=${formatEmail(email)}`
-				};
+		if (isValidEmail(email)) {
+			const opts = {
+				method: 'POST',
+				headers: {
+					'Content-type': 'application/x-www-form-urlencoded'
+				},
+				credentials: 'include',
+				body: `email=${formatEmail(email)}`
+			};
 
-				fetch(options.signupUrl, opts)
-					.then(response => response.text())
-					.then(response => {
-					displaySection.innerHTML = getResponseMsg(response, pageLocation);
-					})
-					.catch(err => console.log(err));
+			fetch(options.signupUrl, opts)
+			.then(response => response.text())
+			.then(response => {
+				displaySection.innerHTML = getResponseMsg(response, pageLocation);
+			})
+			.catch(err => console.log(err));
 
-			} else {
-				toggleValidationErrors();
+		} else {
+			toggleValidationErrors();
+		}
+	});
+
+	closeButton.addEventListener('click', () => {
+		el.style.display = 'none';
+		el.setAttribute('aria-hidden', true);
+	});
+
+	emailField.addEventListener('click', () => {
+		if (lightSignupForm.classList.contains('o-forms--error')) {
+			toggleValidationErrors();
+		}
+	});
+
+	// Validation helpers
+
+	function isValidEmail(email) {
+		return /(.+)@(.+)/.test(email);
+	}
+
+	function toggleValidationErrors() {
+		lightSignupForm.classList.toggle('o-forms--error');
+		invalidEmailMessage.classList.toggle('o-email-only-signup__visually-hidden');
+	}
+
+	function formatEmail(email) {
+		return encodeURIComponent(email.trim()).replace('%20', '+');
+	}
+
+	function optionsFromData(el) {
+		const options = {};
+		Object.keys(defaultOptions).forEach(key => {
+			// convert optionKeyLikeThis to data-o-email-only-signup-option-key-like-this
+			const attr = 'data-o-email-only-signup-' + kebabCase(key);
+			if(el.hasAttribute(attr)) {
+				options[key] = el.getAttribute(attr);
 			}
 		});
 
-		closeButton.addEventListener('click', () => {
-			el.style.display = 'none';
-			el.setAttribute('aria-hidden', true);
-		});
-
-		emailField.addEventListener('click', () => {
-			if (lightSignupForm.classList.contains('o-forms--error')) {
-				toggleValidationErrors();
-			}
-		});
-
-		// Validation helpers
-
-		function isValidEmail(email) {
-			return /(.+)@(.+)/.test(email);
-		}
-
-		function toggleValidationErrors() {
-			lightSignupForm.classList.toggle('o-forms--error');
-			invalidEmailMessage.classList.toggle('o-email-only-signup__visually-hidden');
-		}
-
-		function formatEmail(email) {
-			return encodeURIComponent(email.trim()).replace('%20', '+');
-		}
-
-		function optionsFromData(el) {
-			const options = {};
-			Object.keys(defaultOptions).forEach(key => {
-				// convert optionKeyLikeThis to data-o-email-only-signup-option-key-like-this
-				const attr = 'data-o-email-only-signup-' + kebabCase(key);
-				if(el.hasAttribute(attr)) {
-					options[key] = el.getAttribute(attr);
-				}
-			});
-
-			return options;
-		}
+		return options;
+	}
 };

--- a/src/email-only-signup.js
+++ b/src/email-only-signup.js
@@ -6,14 +6,14 @@ const defaultOptions = {
 };
 
 export function getResponseMsg(response, pageLocation) {
-		// Keep marketing copy somewhere
-		const responseMsg = {
-			'SUBSCRIPTION_SUCCESSFUL': 'Thanks – look out for your first briefing soon.',
-			'INVALID_REQUEST': 'Sorry, something went wrong. Please try again.',
-			'ALREADY_SUBSCRIBED': 'It looks like you’re currently receiving the daily top stories summary email. If you’re interested in getting access to more FT content, why not <a target="_blank" style="text-decoration:none;color:#27757B;" href="/products?segID=0801043">sign up to a 4 week Trial</a>?',
-			'USER_ARCHIVED': 'It looks like you’ve signed up to the daily top stories summary email before. If you’re interested in getting access to more FT content, why not <a target="_blank" style="text-decoration:none;color:#27757B;" href="/products?segID=0801043">sign up to a 4 week Trial</a>?',
-			'USER_NOT_ANONYMOUS': `It looks like you already have an account with us. <a href="/login?location=${pageLocation}" style="text-decoration:none;color:#27757B;">Sign in</a>.`
-		};
+	// Keep marketing copy somewhere
+	const responseMsg = {
+		'SUBSCRIPTION_SUCCESSFUL': 'Thanks – look out for your first briefing soon.',
+		'INVALID_REQUEST': 'Sorry, something went wrong. Please try again.',
+		'ALREADY_SUBSCRIBED': 'It looks like you’re currently receiving the daily top stories summary email. If you’re interested in getting access to more FT content, why not <a target="_blank" style="text-decoration:none;color:#27757B;" href="/products?segID=0801043">sign up to a 4 week Trial</a>?',
+		'USER_ARCHIVED': 'It looks like you’ve signed up to the daily top stories summary email before. If you’re interested in getting access to more FT content, why not <a target="_blank" style="text-decoration:none;color:#27757B;" href="/products?segID=0801043">sign up to a 4 week Trial</a>?',
+		'USER_NOT_ANONYMOUS': `It looks like you already have an account with us. <a href="/login?location=${pageLocation}" style="text-decoration:none;color:#27757B;">Sign in</a>.`
+	};
 
 	return responseMsg[response] ? responseMsg[response] : responseMsg.INVALID_REQUEST;
 }

--- a/src/email-only-signup.js
+++ b/src/email-only-signup.js
@@ -5,9 +5,8 @@ const defaultOptions = {
 	signupUrl: '/signup/api/light-signup'
 };
 
-export function getResponseMsg(response) {
+export function getResponseMsg(response, pageLocation) {
 		// Keep marketing copy somewhere
-		const pageLocation = window.location.href;
 		const responseMsg = {
 			'SUBSCRIPTION_SUCCESSFUL': 'Thanks – look out for your first briefing soon.',
 			'INVALID_REQUEST': 'Sorry, something went wrong. Please try again.',
@@ -28,6 +27,8 @@ export function init(el, options = {}) {
 	const emailField = el.querySelector('input[name=email]');
 	const invalidEmailMessage = el.querySelector('[data-o-email-only-signup-email-error]');
 
+	const pageLocation = window.location.href;
+
 		// Handle user interaction
 		lightSignupForm.addEventListener('submit', (e) => {
 			e.preventDefault();
@@ -47,7 +48,7 @@ export function init(el, options = {}) {
 				fetch(options.signupUrl, opts)
 					.then(response => response.text())
 					.then(response => {
-					displaySection.innerHTML = getResponseMsg(response);
+					displaySection.innerHTML = getResponseMsg(response, pageLocation);
 					})
 					.catch(err => console.log(err));
 

--- a/src/email-only-signup.js
+++ b/src/email-only-signup.js
@@ -5,21 +5,9 @@ const defaultOptions = {
 	signupUrl: '/signup/api/light-signup'
 };
 
-export default {
-
-	init(el, options = {}) {
-		defaultsDeep(options, optionsFromData(el), defaultOptions);
-
-		const closeButton = el.querySelector('[data-o-email-only-signup-close]');
-		const lightSignupForm = el.querySelector('[data-o-email-only-signup-form]');
-		const displaySection = el.querySelector('[data-o-email-only-signup-completion-message]');
-		const emailField = el.querySelector('input[name=email]');
-		const invalidEmailMessage = el.querySelector('[data-o-email-only-signup-email-error]');
-
+export function getResponseMsg(response) {
 		// Keep marketing copy somewhere
-
 		const pageLocation = window.location.href;
-
 		const responseMsg = {
 			'SUBSCRIPTION_SUCCESSFUL': 'Thanks – look out for your first briefing soon.',
 			'INVALID_REQUEST': 'Sorry, something went wrong. Please try again.',
@@ -28,8 +16,19 @@ export default {
 			'USER_NOT_ANONYMOUS': `It looks like you already have an account with us. <a href="/login?location=${pageLocation}" style="text-decoration:none;color:#27757B;">Sign in</a>.`
 		};
 
-		// Handle user interaction
+	return responseMsg[response] ? responseMsg[response] : responseMsg.INVALID_REQUEST;
+}
 
+export function init(el, options = {}) {
+	defaultsDeep(options, optionsFromData(el), defaultOptions);
+
+	const closeButton = el.querySelector('[data-o-email-only-signup-close]');
+	const lightSignupForm = el.querySelector('[data-o-email-only-signup-form]');
+	const displaySection = el.querySelector('[data-o-email-only-signup-completion-message]');
+	const emailField = el.querySelector('input[name=email]');
+	const invalidEmailMessage = el.querySelector('[data-o-email-only-signup-email-error]');
+
+		// Handle user interaction
 		lightSignupForm.addEventListener('submit', (e) => {
 			e.preventDefault();
 
@@ -48,7 +47,7 @@ export default {
 				fetch(options.signupUrl, opts)
 					.then(response => response.text())
 					.then(response => {
-						displaySection.innerHTML = responseMsg[response] ? responseMsg[response] : responseMsg["INVALID_REQUEST"];
+					displaySection.innerHTML = getResponseMsg(response);
 					})
 					.catch(err => console.log(err));
 
@@ -95,5 +94,4 @@ export default {
 
 			return options;
 		}
-	}
 };


### PR DESCRIPTION
Instant Articles can't use the fetch form submit, so we're doing a regular form submit and rendering a template. Having these messages available would mean we don't have to duplicate them.