### PR TITLE
Bump o-typography

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,6 @@
     "o-colors": "^3.3.2",
     "o-forms": "^2.0.0",
     "o-icons": "^4.4.2",
-    "o-typography": "^3.1.1"
+    "o-typography": "^4.3.1"
   }
 }


### PR DESCRIPTION
Having to do a resolution for this outlier that is currently on v3 of o-typography.

Any reason why it can't be bumped up?