### PR TITLE
use new image service

### DIFF
--- a/src/email-only-signup.scss
+++ b/src/email-only-signup.scss
@@ -75,7 +75,7 @@
     }
 
     &:first-child {
-      background: url('https://next-geebee.ft.com/image/v1/images/raw/https%3a%2f%2fnext-geebee.ft.com%2fassets%2fmyft-alerts-prefs%2fenvelope.svg?source=next&fit=scale-down&compression=best&width=40') 100% 0 no-repeat;
+      background: url('https://www.ft.com/__origami/service/image/v2/images/raw/https%3a%2f%2fnext-geebee.ft.com%2fassets%2fmyft-alerts-prefs%2fenvelope.svg?source=next&fit=scale-down&compression=best&width=40') 100% 0 no-repeat;
       padding-right: 45px;
     }
 


### PR DESCRIPTION
We launched the new image service 6 days ago, I'm currently going around FT projects and helping them migrate to it.

The new Image Service includes a lot of improvements:
- The application is multi-region with failover
- We use stale-on-error and stale-while-revalidate cache extensions to ensure users get stale content if the application errors or has to revalidate an image
- We serve much smaller WebP and JPEG XR images to supported browsers
- We’ve seen a reduction in file size for a large number of image requests
- We’re now serving images over H2