### PR TITLE
At/deprecate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # o-email-only-signup
 
-#### :warning: This componented has been deprecated.
+#### :warning: This component has been deprecated.
 **The endpoints detailed in [configuration](#configuration) no longer exist. You could use https://github.com/Financial-Times/newsletter-signup to mount the required endpoints via a different application if needed.**
 
 ----

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # o-email-only-signup
 
+#### :warning: This componented has been deprecated.
+**The endpoints detailed in [configuration](#configuration) no longer exist. You could use https://github.com/Financial-Times/newsletter-signup to mount the required endpoints via a different application if needed.**
+
+----
+
 Light sign-up form.
 
 - [Usage](#usage)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # o-email-only-signup
 
 #### :warning: This component has been deprecated.
-**The endpoints detailed in [configuration](#configuration) no longer exist. You could use https://github.com/Financial-Times/newsletter-signup to mount the required endpoints via a different application if needed.**
+**The endpoints detailed in [configuration](#configuration) no longer exist. You could use [newsletter-signup](https://github.com/Financial-Times/newsletter-signup) to mount the required endpoints via a different application if needed.**
 
 ----
 

--- a/origami.json
+++ b/origami.json
@@ -4,7 +4,7 @@
     "origamiCategory": "components",
     "origamiVersion": 1,
     "support": "next.team@ft.com",
-    "supportStatus": "active",
+    "supportStatus": "deprecated",
     "runServer": "true",
     "demosDefaults": {
         "sass": "demos/src/demo.scss",


### PR DESCRIPTION
**Light signup aka. email only signup as a feature is being deprecated**

The value generated by the feature was deemed inadequate.

Previously the component appeared:
 - in article (when anon, so first click free or free content) - PR pending.
 - stream pages, at the top, promoting "firstft" or "top stories" (again when anon) - https://github.com/Financial-Times/next-stream-page/pull/1848.
 - within AMP (as elaborated by @quarterto)
- there was also a stray reference in: https://github.com/Financial-Times/next-corp-signup/pull/46

However the feature has been turned off (and flags removed) as of the end of last month (May 2017).

The endpoints used by the form were mounted on `/signup/light-signup`via the signup application. These are going to be removed (https://github.com/Financial-Times/next-signup/pull/1041). However the handlers still exist within: https://github.com/Financial-Times/newsletter-signup which will be removed eventually - https://github.com/Financial-Times/newsletter-signup/pull/28

Currently there are no users on the Light Signup mailing list, as a user gets removed after 7 days automatically. So it is safe to do the cleanup. 